### PR TITLE
Support supplying args when executing query

### DIFF
--- a/qframe.go
+++ b/qframe.go
@@ -1070,7 +1070,7 @@ func ReadSQL(tx *sql.Tx, confFuncs ...qsql.ConfigFunc) QFrame {
 	return ReadSQLWithArgs(tx, []interface{}{}, confFuncs...)
 }
 
-// ReadSQLPreparedreturns a QFrame by reading the results of a SQL query with arguments
+// ReadSQLWithArgs returns a QFrame by reading the results of a SQL query with arguments
 func ReadSQLWithArgs(tx *sql.Tx, queryArgs []interface{}, confFuncs ...qsql.ConfigFunc) QFrame {
 	conf := qsql.NewConfig(confFuncs)
 	// The MySQL can only use prepared

--- a/qframe.go
+++ b/qframe.go
@@ -1067,6 +1067,11 @@ func ReadJSON(reader io.Reader, confFuncs ...newqf.ConfigFunc) QFrame {
 
 // ReadSQL returns a QFrame by reading the results of a SQL query.
 func ReadSQL(tx *sql.Tx, confFuncs ...qsql.ConfigFunc) QFrame {
+	return ReadSQLWithArgs(tx, []interface{}{}, confFuncs...)
+}
+
+// ReadSQLPreparedreturns a QFrame by reading the results of a SQL query with arguments
+func ReadSQLWithArgs(tx *sql.Tx, queryArgs []interface{}, confFuncs ...qsql.ConfigFunc) QFrame {
 	conf := qsql.NewConfig(confFuncs)
 	// The MySQL can only use prepared
 	// statements to return "native" types, otherwise
@@ -1077,7 +1082,7 @@ func ReadSQL(tx *sql.Tx, confFuncs ...qsql.ConfigFunc) QFrame {
 		return QFrame{Err: err}
 	}
 	defer stmt.Close()
-	rows, err := stmt.Query()
+	rows, err := stmt.Query(queryArgs...)
 	if err != nil {
 		return QFrame{Err: err}
 	}


### PR DESCRIPTION
Thank you for an awesome Go dataframe library to work with!

While looking to create a QFrame via SQL, I noticed that queries did not support supplying arguments to prepared statements. As supplying arguments to prepared statements is one tool to help prevent against SQL injection, I could not use ReadSQL as it currently is implemented.
This PR adds a new method ReadSQLWithArgs that supports this use case.

To test that this would work with supported databases, I also created a stand alone repo for integration testing (that I believe would likely be out of scope for the qframe repo itself):
https://github.com/jrkhan/qframe_integration_test
It spins up MySQL and Postgres via docker compose (and SQLite from within the test), and runs tests ensuring building QFrames from SQL from each database works as expected.
